### PR TITLE
Integrate modulator into daemon loop

### DIFF
--- a/echo_daemon.py
+++ b/echo_daemon.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from agents.intuition import IntuitionAgent
 from agents.navigator import NavigatorAgent
 from agents.curiosity_agent import CuriosityAgent
+from agents.modulator import ModulatorAgent
 from echo_logger import log_custom_event
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -31,10 +32,15 @@ def daemon_loop():
         intuition = IntuitionAgent()
         navigator = NavigatorAgent()
         curiosity = CuriosityAgent()
+        modulator = ModulatorAgent()
 
         # Load memory signals
         pressure_data = load_yaml(PRESSURE_PATH)
         goal_data = load_yaml(GOALS_PATH)
+
+        # Run modulator to adapt agent weights
+        modulator.run()
+        log_custom_event("🔧 ModulatorAgent updated agent weights")
 
         top_motifs = intuition.get_resonant_tags()[:3]
         prompt_targets = navigator.get_next_prompt_targets()

--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -108,3 +108,10 @@ Purpose: Generate introspective questions based on unresolved motifs without goa
 
 Future entries can follow the same format using Design Intent 0010 and so on.
 
+---
+
+🔁 Design Intent 0010: Daemon Self-Modulation
+
+Date: 2025-06-28
+Purpose: Integrate ModulatorAgent into echo_daemon so agent weights adapt automatically each cycle.
+


### PR DESCRIPTION
## Summary
- run `ModulatorAgent` during every daemon cycle
- log event when weights are updated
- document the daemon's self-modulation integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc86671bc832fb738b2774951bfa1