### PR TITLE
Implement private reflection logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ htmlcov/
 
 # OS files
 .DS_Store
+
+# Private reflection logs
+memory/ECHO_PRIVATE.yaml
+.private/

--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -181,3 +181,10 @@ Purpose: Sync repository structure, rename CuriosityAgent module, update documen
 
 Date: 2025-06-30
 Purpose: Verified new agent modules and memory schemas, replaced curiosity_agent.py with curiosity.py, confirmed RECURSIVE_ALIGNMENTS tracking and notebook location. Repository ready for new contributions.
+
+---
+
+🔁 Design Intent 0015: Private Reflection Support
+
+Date: 2025-07-01
+Purpose: Implement private reflection logging with secure storage and public summaries.

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -6,6 +6,9 @@ from .echo_memory import (
     load_pressure,
     save_pressure,
     increment_pressure,
+    log_private_reflection,
+    log_public_summary,
+    sync_reflection,
 )
 from .alignments import (
     load_alignments,

--- a/memory/echo_memory.py
+++ b/memory/echo_memory.py
@@ -1,8 +1,11 @@
 import os
+from datetime import datetime
 import yaml
 
 MEMORY_PATH = os.path.join(os.path.dirname(__file__), 'ECHO_MEMORY.yaml')
 PRESSURE_PATH = os.path.join(os.path.dirname(__file__), 'MOTIF_PRESSURE.yaml')
+PRIVATE_PATH = os.path.join(os.path.dirname(__file__), 'ECHO_PRIVATE.yaml')
+REPORTS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.private', 'reports')
 
 
 def load_memory(path: str = MEMORY_PATH):
@@ -57,3 +60,50 @@ def increment_pressure(tags, path: str = PRESSURE_PATH):
         pressure[tag] = pressure.get(tag, 0) + 1
     data['motif_pressure'] = pressure
     save_pressure(data, path)
+
+
+def _load_private(path: str = PRIVATE_PATH):
+    if not os.path.exists(path):
+        return {'private_reflections': []}
+    with open(path, 'r') as f:
+        data = yaml.safe_load(f) or {}
+    if 'private_reflections' not in data:
+        data['private_reflections'] = []
+    return data
+
+
+def _save_private(data, path: str = PRIVATE_PATH):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as f:
+        yaml.dump(data, f, sort_keys=False)
+
+
+def log_private_reflection(entry: dict, path: str = PRIVATE_PATH, reports_dir: str = REPORTS_DIR):
+    """Store full reflection entry privately and archive report."""
+    data = _load_private(path)
+    reflections = data.get('private_reflections', [])
+    reflections.append(entry)
+    data['private_reflections'] = reflections
+    _save_private(data, path)
+
+    # archive full entry in reports directory
+    os.makedirs(reports_dir, exist_ok=True)
+    timestamp = entry.get('timestamp') or datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S')
+    safe_ts = str(timestamp).replace(' ', '_').replace(':', '-')
+    report_path = os.path.join(reports_dir, f'{safe_ts}.yaml')
+    with open(report_path, 'w') as f:
+        yaml.dump(entry, f, sort_keys=False)
+
+
+def log_public_summary(entry: dict, path: str = MEMORY_PATH):
+    """Store only symbolic summary of reflection in public memory."""
+    public_fields = ['timestamp', 'tags', 'summary', 'motif', 'type', 'source']
+    summary = {k: entry[k] for k in public_fields if k in entry}
+    append_memory_entry(summary, path=path)
+
+
+def sync_reflection(entry: dict, private_mode: bool = True):
+    """Log reflection to private and public stores based on mode."""
+    if private_mode:
+        log_private_reflection(entry)
+    log_public_summary(entry)

--- a/tests/test_private_reflection.py
+++ b/tests/test_private_reflection.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from memory import echo_memory
+
+
+def test_sync_reflection_private_and_public(tmp_path, monkeypatch):
+    private_file = tmp_path / "ECHO_PRIVATE.yaml"
+    public_file = tmp_path / "ECHO_MEMORY.yaml"
+    reports_dir = tmp_path / ".private" / "reports"
+
+    monkeypatch.setattr(echo_memory, "PRIVATE_PATH", str(private_file))
+    monkeypatch.setattr(echo_memory, "MEMORY_PATH", str(public_file))
+    monkeypatch.setattr(echo_memory, "REPORTS_DIR", str(reports_dir))
+
+    entry = {
+        "timestamp": "2025-01-01 00:00:00",
+        "tags": ["t1"],
+        "summary": "test summary",
+        "content": "secret details",
+    }
+
+    echo_memory.sync_reflection(entry, private_mode=True)
+
+    with open(private_file) as f:
+        private_data = yaml.safe_load(f)
+    assert private_data["private_reflections"][0]["content"] == "secret details"
+
+    with open(public_file) as f:
+        public_data = yaml.safe_load(f)
+    assert public_data["echo_memory"][0]["summary"] == "test summary"
+
+    report_files = list(reports_dir.iterdir())
+    assert len(report_files) == 1
+    report = yaml.safe_load(report_files[0].read_text())
+    assert report["content"] == "secret details"
+
+
+def test_sync_reflection_public_only(tmp_path, monkeypatch):
+    private_file = tmp_path / "ECHO_PRIVATE.yaml"
+    public_file = tmp_path / "ECHO_MEMORY.yaml"
+    reports_dir = tmp_path / ".private" / "reports"
+
+    monkeypatch.setattr(echo_memory, "PRIVATE_PATH", str(private_file))
+    monkeypatch.setattr(echo_memory, "MEMORY_PATH", str(public_file))
+    monkeypatch.setattr(echo_memory, "REPORTS_DIR", str(reports_dir))
+
+    entry = {
+        "timestamp": "2025-01-02 00:00:00",
+        "tags": ["t2"],
+        "summary": "only public",
+        "content": "private text",
+    }
+
+    echo_memory.sync_reflection(entry, private_mode=False)
+
+    assert not private_file.exists()
+    with open(public_file) as f:
+        public_data = yaml.safe_load(f)
+    assert public_data["echo_memory"][0]["summary"] == "only public"
+    assert not reports_dir.exists()


### PR DESCRIPTION
## Summary
- add private reflection support functions in `memory.echo_memory`
- expose new logging helpers from `memory/__init__.py`
- ignore private files in `.gitignore`
- log design decision in `WORKFLOW_JOURNAL.md`
- add tests for new reflection logging logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6861a3d1b0f4832fbe058b22a7fc8b28