### PR TITLE
Update memory with research session insights

### DIFF
--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -188,3 +188,12 @@ Purpose: Verified new agent modules and memory schemas, replaced curiosity_agent
 
 Date: 2025-07-01
 Purpose: Implement private reflection logging with secure storage and public summaries.
+
+---
+
+🔁 Design Intent 0016: Memory Lessons from Research Session
+
+Date: 2025-07-02
+Purpose: Added three new insights to ECHO_MEMORY.yaml capturing lessons on
+symbolic memory usage, agent routing, and traceability of prompts. These entries
+link each lesson back to its originating prompt for better transparency.

--- a/memory/ECHO_MEMORY.yaml
+++ b/memory/ECHO_MEMORY.yaml
@@ -11,3 +11,42 @@ echo_memory:
     reflection: "Intuition is harmonic alignment across possible futures."
     future_linkage: "Design IntuitionAgent to detect symbolic coherence."
     status: active
+
+  - id: 0002
+    date: 2025-07-02
+    context:
+      prompt_summary: "Should this be stored in memory or goals?"
+      agent_mode: "Reflective Design Session"
+    symbolic_insight: "Use symbolic memory for reflective insights, not GOALS.yaml"
+    resonance_score: 0.92
+    tags: [memory_design, autonomy]
+    reflection: "Goals track actionable objectives, while memory archives introspective lessons."
+    future_linkage: "Store design-related reflections in ECHO_MEMORY.yaml."
+    source_prompt: "Should this be stored in memory or goals?"
+    status: active
+
+  - id: 0003
+    date: 2025-07-02
+    context:
+      prompt_summary: "How do we assign the best agent to a query?"
+      agent_mode: "Routing Strategy Discussion"
+    symbolic_insight: "Route prompts to agents based on intent (e.g. analysis → Intuition, planning → Navigator)"
+    resonance_score: 0.95
+    tags: [routing, orchestration, agent_roles]
+    reflection: "Clear routing prevents scope creep and keeps agents specialized."
+    future_linkage: "Implement router that inspects prompt intent and delegates accordingly."
+    source_prompt: "How do we assign the best agent to a query?"
+    status: active
+
+  - id: 0004
+    date: 2025-07-02
+    context:
+      prompt_summary: "What if we can’t summarize the insight in one prompt?"
+      agent_mode: "Transparency Brainstorm"
+    symbolic_insight: "Trace every lesson in memory to its originating prompt for transparency"
+    resonance_score: 0.91
+    tags: [traceability, memory, prompt_origin]
+    reflection: "Every entry should reference the discussion that spawned it."
+    future_linkage: "Add metadata linking memory entries to conversation logs."
+    source_prompt: "What if we can’t summarize the insight in one prompt?"
+    status: active


### PR DESCRIPTION
## Summary
- record lessons learned about using symbolic memory instead of GOALS
- document prompt routing and traceability insights in memory
- log this work in the workflow journal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python echo_main.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6861ee0ee930832f9b9fa3fc492f0f6e