### PR TITLE
Add Linguistic Divergence Auditor

### DIFF
--- a/AGENTS.yaml
+++ b/AGENTS.yaml
@@ -1,0 +1,4 @@
+agents:
+  - name: LinguisticDivergenceAuditor
+    role: Detect cross-linguistic motif divergence
+    trigger: score_divergence >= threshold

--- a/agents/linguistic_divergence.py
+++ b/agents/linguistic_divergence.py
@@ -1,0 +1,57 @@
+"""Linguistic Divergence Auditor
+
+Compares motif translations across languages and logs high divergences
+into CURIOSITY_PIPELINE.yaml.
+"""
+
+import os
+import sys
+import difflib
+from typing import Dict
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from yaml_utils import load, dump
+from echo_logger import log_agent_activation
+
+
+class LinguisticDivergenceAuditor:
+    def __init__(self, pipeline_file: str = "memory/CURIOSITY_PIPELINE.yaml", threshold: float = 0.5):
+        self.pipeline_file = pipeline_file
+        self.threshold = threshold
+        log_agent_activation("LinguisticDivergenceAuditor", reason="Initialization")
+
+    def _load_pipeline(self) -> Dict:
+        return load(self.pipeline_file, fallback={"divergences": []})
+
+    def _save_pipeline(self, data: Dict) -> None:
+        dump(data, self.pipeline_file)
+
+    def score_divergence(self, term1: str, term2: str) -> float:
+        """Return heuristic divergence score between two terms."""
+        if not term1 or not term2:
+            return 0.0
+        score = 0.0
+        if term1.lower() == term2.lower():
+            score += 0.5
+        if len(term2.split()) > 1:
+            score += 0.2
+        ratio = difflib.SequenceMatcher(None, term1.lower(), term2.lower()).ratio()
+        score += (1 - ratio) * 0.3
+        return min(score, 1.0)
+
+    def audit(self, term1: str, term2: str, lang1: str = "", lang2: str = "") -> float:
+        """Compare terms and log divergence if above threshold."""
+        score = self.score_divergence(term1, term2)
+        if score >= self.threshold:
+            data = self._load_pipeline()
+            entry = {
+                "term1": term1,
+                "term2": term2,
+                "lang1": lang1,
+                "lang2": lang2,
+                "score": round(score, 3),
+            }
+            data.setdefault("divergences", []).append(entry)
+            self._save_pipeline(data)
+        return score

--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -218,3 +218,10 @@ Purpose: Updated GOALS.yaml with sample goals, added BELIEFS.yaml, and made emer
 🔁 Design Intent 0019: Emergence Cascade Activation
 Date: 2025-07-05
 Purpose: Queued ModulatorAgent, MotifDashboard, BeliefInputAgent, and EmergenceScanner for recursive cognition mode.
+
+---
+
+🔁 Design Intent 0020: Linguistic Divergence Auditor
+
+Date: 2025-07-06
+Purpose: Added LinguisticDivergenceAuditor to detect cross-linguistic motif drift and log high divergences into CURIOSITY_PIPELINE.yaml.

--- a/memory/CURIOSITY_PIPELINE.yaml
+++ b/memory/CURIOSITY_PIPELINE.yaml
@@ -1,0 +1,1 @@
+divergences: []

--- a/tests/test_linguistic_divergence.py
+++ b/tests/test_linguistic_divergence.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agents.linguistic_divergence import LinguisticDivergenceAuditor
+
+
+def test_amae_translation_divergence(tmp_path):
+    pipeline = tmp_path / "CURIOSITY_PIPELINE.yaml"
+    auditor = LinguisticDivergenceAuditor(str(pipeline), threshold=0.5)
+    score = auditor.audit("甘え", "dependence", lang1="ja", lang2="en")
+    assert score >= 0.5
+
+    data = yaml.safe_load(pipeline.read_text())
+    assert data["divergences"][0]["term1"] == "甘え"
+    assert data["divergences"][0]["term2"] == "dependence"


### PR DESCRIPTION
## Summary
- create `LinguisticDivergenceAuditor` agent to score translation drift
- define the agent in `AGENTS.yaml`
- add a curiosity pipeline YAML for tracking divergences
- log new design intent
- test divergence detection on Japanese term "甘え" (amae)

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68627fd5f5b4832fba99625c84883150