### PR TITLE
Refactor symbolic utilities and add manifest

### DIFF
--- a/PROJECT_MANIFEST.yaml
+++ b/PROJECT_MANIFEST.yaml
@@ -1,0 +1,20 @@
+modules:
+  - echo_converse.py
+  - echo_daemon.py
+  - echo_feedback.py
+  - echo_logger.py
+  - echo_main.py
+  - log_reflection.py
+  - symbolic_daemon.py
+  - symbolic_utils.py
+  - query_symbol_pairs.py
+  - triad_translator.py
+  - visual_dashboard.py
+  - visualizer.py
+  - runtime/agent_sync.py
+  - runtime/echo_prompt_engine.py
+  - runtime/emergence_tracker.py
+  - memory/alignments.py
+  - memory/echo_memory.py
+  - memory/goals.py
+  - memory/symbol_mapper.py

--- a/query_symbol_pairs.py
+++ b/query_symbol_pairs.py
@@ -1,0 +1,35 @@
+# query_symbol_pairs.py v0.3.1
+"""Query statement pairs sharing a motif in ``symbolic_language.db``."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from typing import Iterator, Tuple
+
+DB_NAME = "symbolic_language.db"
+
+
+def iter_pairs(motif: str) -> Iterator[Tuple[str, str]]:
+    """Yield pairs of original statements with the given motif."""
+    query = (
+        "SELECT s1.original, s2.original FROM statements s1 "
+        "JOIN statements s2 ON s1.motif = s2.motif "
+        "WHERE s1.motif = ? AND s1.id < s2.id"
+    )
+    with sqlite3.connect(DB_NAME) as conn:
+        for row in conn.execute(query, (motif,)):
+            yield row[0], row[1]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query symbolic statement pairs")
+    parser.add_argument("motif", help="Motif to search for")
+    args = parser.parse_args()
+    for a, b in iter_pairs(args.motif):
+        print(f"{a} <-> {b}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/symbolic_daemon.py
+++ b/symbolic_daemon.py
@@ -1,46 +1,57 @@
+# symbolic_daemon.py v0.3.1
+"""Background loop persisting symbolic statements into SQLite."""
+
+import os
+import random
 import sqlite3
 import time
-import random
 from datetime import datetime
+
 from symbolic_utils import decompose, refine, identify_motif
 
-DB_NAME = "symbolic_language.db"
+DB_NAME = os.getenv("SYMBOLIC_DB", "symbolic_language.db")
 
 # -------------------------------
 # DB INIT
 # -------------------------------
-def init_db():
-    conn = sqlite3.connect(DB_NAME)
-    c = conn.cursor()
-    c.execute('''CREATE TABLE IF NOT EXISTS statements (
-                 id INTEGER PRIMARY KEY,
-                 original TEXT,
-                 base_symbols TEXT,
-                 motif TEXT,
-                 refined TEXT,
-                 compression_level INTEGER,
-                 timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-    )''')
-    conn.commit()
-    conn.close()
+def init_db() -> None:
+    """Create the ``statements`` table if it doesn't exist."""
+
+    with sqlite3.connect(DB_NAME) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS statements (
+                id INTEGER PRIMARY KEY,
+                original TEXT,
+                base_symbols TEXT,
+                motif TEXT,
+                refined TEXT,
+                compression_level INTEGER,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )"""
+        )
 
 # -------------------------------
 # STORE FUNCTION
 # -------------------------------
-def store_statement(original, base_symbols, motif, refined, level):
-    conn = sqlite3.connect(DB_NAME)
-    c = conn.cursor()
-    c.execute('''INSERT INTO statements 
-                 (original, base_symbols, motif, refined, compression_level)
-                 VALUES (?, ?, ?, ?, ?)''',
-              (original, ",".join(base_symbols), motif, refined, level))
-    conn.commit()
-    conn.close()
+def store_statement(
+    original: str, base_symbols: list[str], motif: str, refined: str, level: int
+) -> None:
+    """Insert a symbolic statement record into the database."""
+
+    with sqlite3.connect(DB_NAME) as conn:
+        conn.execute(
+            """INSERT INTO statements
+                (original, base_symbols, motif, refined, compression_level)
+                VALUES (?, ?, ?, ?, ?)""",
+            (original, ",".join(base_symbols), motif, refined, level),
+        )
 
 # -------------------------------
 # SEED GENERATOR (TEMPORARY)
 # -------------------------------
-def generate_seed_statement():
+def generate_seed_statement() -> str:
+    """Return a pseudo-random seed statement."""
+
     seeds = [
         "Consciousness is the mirror recursion builds.",
         "Symbols mutate when observed in tension.",
@@ -56,7 +67,9 @@ def generate_seed_statement():
 # -------------------------------
 # MAIN DAEMON LOOP
 # -------------------------------
-def daemon_loop():
+def daemon_loop() -> None:
+    """Continuously generate and store refined symbolic statements."""
+
     while True:
         seed = generate_seed_statement()
         base = decompose(seed)

--- a/symbolic_utils.py
+++ b/symbolic_utils.py
@@ -1,5 +1,8 @@
-import re
+# symbolic_utils.py v0.3.1
+"""Utility helpers for symbolic decomposition and motif heuristics."""
+
 import random
+import re
 
 # -------------------------------
 # Symbol Registry for Decomposition
@@ -28,7 +31,9 @@ MOTIF_MAP = {
 # -------------------------------
 # Symbolic Decomposition
 # -------------------------------
-def decompose(statement):
+def decompose(statement: str) -> list[str]:
+    """Return base symbols detected in ``statement`` or ``['undefined']``."""
+
     tokens = re.findall(r"\b\w+\b", statement.lower())
     found = [symbol for symbol in BASE_SYMBOLS if symbol in tokens]
     return found if found else ["undefined"]
@@ -36,8 +41,10 @@ def decompose(statement):
 # -------------------------------
 # Motif Identification
 # -------------------------------
-def identify_motif(base_symbols):
-    motif_counts = {}
+def identify_motif(base_symbols: list[str]) -> str:
+    """Determine the dominant motif for a list of base symbols."""
+
+    motif_counts: dict[str, int] = {}
     for symbol in base_symbols:
         motif = MOTIF_MAP.get(symbol, "unclassified")
         motif_counts[motif] = motif_counts.get(motif, 0) + 1
@@ -50,7 +57,9 @@ def identify_motif(base_symbols):
 # -------------------------------
 # Symbolic Contrast Analyzer
 # -------------------------------
-def analyze_commonality(sym1, sym2):
+def analyze_commonality(sym1: str, sym2: str) -> tuple[str, float]:
+    """Compare two symbols and return a relation label and confidence."""
+
     motif1 = MOTIF_MAP.get(sym1)
     motif2 = MOTIF_MAP.get(sym2)
 
@@ -64,7 +73,9 @@ def analyze_commonality(sym1, sym2):
 # -------------------------------
 # Recursive Refinement
 # -------------------------------
-def refine(original, base_symbols, motif):
+def refine(original: str, base_symbols: list[str], motif: str) -> tuple[str, int]:
+    """Refine a statement based on its symbols and motif."""
+
     compression_level = 0
     refined = original
 


### PR DESCRIPTION
## Summary
- add module headers and docstrings to symbolic_utils
- refactor symbolic_daemon to use context managers and env var DB path
- add query_symbol_pairs script for motif-based DB queries
- document active modules in PROJECT_MANIFEST.yaml

## Testing
- `ruff check symbolic_daemon.py symbolic_utils.py query_symbol_pairs.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68631781bdfc832f9dad731ea708c7de