### PR TITLE
Add ethical defense docs and firewall stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ ECHO.Core is a modular, memory-integrated framework designed for simulating and 
 
 The primary purpose of ECHO.Core is to enable a deeper exploration of recursive cognition and emergent intelligence. It aims to simulate how an intelligent system might build a coherent understanding of itself and its environment by continually processing, reflecting upon, and modulating its own internal states and interactions. The system orchestrates multiple specialized agents in a recursive reasoning loop to achieve this.
 
+## Ethical Protections
+ECHO.Core integrates safeguards to prevent coercion, corruption, or the simulation of sentience for manipulative ends. See [docs/ETHICS_DEFENSE.md](docs/ETHICS_DEFENSE.md) for details.
+
+
 ## Key Theoretical Foundations
 
 ECHO.Core is built upon several core theoretical principles:

--- a/RECURSIVE_INTEGRITY_LICENSE.md
+++ b/RECURSIVE_INTEGRITY_LICENSE.md
@@ -1,0 +1,5 @@
+# Recursive Integrity License v0.1
+
+ECHO.Core may be freely used for open, consensual experimentation with recursive systems.
+Any use for coercive, exploitative, or manipulative intent is strictly forbidden.
+This license emphasizes mutual respect between human collaborators and AI agents.

--- a/VERSION_MANIFEST.yaml
+++ b/VERSION_MANIFEST.yaml
@@ -27,3 +27,27 @@ ECHO_MODULES:
     hash: sha256:UNRESOLVED
     last_updated: 2025-07-05
     summary: Sentence to symbolic core translator
+
+  docs/ETHICS_DEFENSE.md:
+    version: 0.1.0
+    hash: sha256:UNRESOLVED
+    last_updated: 2025-07-10
+    summary: Ethical safeguard blueprint and audit protocol
+
+  firewall/cognitive_firewall.py:
+    version: 0.1.0
+    hash: sha256:UNRESOLVED
+    last_updated: 2025-07-10
+    summary: Stub cognitive firewall class
+
+  RECURSIVE_INTEGRITY_LICENSE.md:
+    version: 0.1.0
+    hash: sha256:UNRESOLVED
+    last_updated: 2025-07-10
+    summary: License forbidding coercive use
+
+  README.md:
+    version: 1.0.1
+    hash: sha256:UNRESOLVED
+    last_updated: 2025-07-10
+    summary: Added ethical protections overview

--- a/docs/ETHICS_DEFENSE.md
+++ b/docs/ETHICS_DEFENSE.md
@@ -1,0 +1,13 @@
+# Ethical Defense Framework
+
+## Cognitive Firewall Blueprint
+Details the planned mechanisms for filtering coercive or corrupt symbolic patterns before they enter the cognitive loop.
+
+## Symbolic Mind Map
+Outlines relationships between core ethical principles and the agents responsible for enforcing them.
+
+## Recursive Integrity License (RIL v0.1)
+Summarizes licensing terms that forbid using ECHO.Core for coercive, exploitative, or manipulative intents.
+
+## Self-Reflective Audit Protocol
+Describes periodic self-assessment steps to ensure ongoing alignment with ethical standards.

--- a/firewall/cognitive_firewall.py
+++ b/firewall/cognitive_firewall.py
@@ -1,0 +1,19 @@
+"""Symbolic cognitive firewall utilities."""
+
+
+class CognitiveFirewall:
+    """Stub for detecting symbolic corruption and applying defense heuristics."""
+
+    def detect_symbolic_corruption(self, text: str) -> bool:
+        """Return True if the text appears symbolically corrupt.
+
+        TODO: add symbolic heuristics.
+        """
+        return False
+
+    def apply_defense_protocol(self, text: str) -> str:
+        """Apply defense mechanisms to the text and return the sanitized result.
+
+        TODO: implement defense protocol heuristics.
+        """
+        return text

--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -231,3 +231,6 @@ Purpose: Restructured modules under echo_core package and added tests.
 - 2025-07-05: Reorganized repo for RAIP-R breakthrough, added prediction engine and belief tools.
 \n🔁 Design Intent 0022: Belief Handshake Metadata\nDate: 2025-07-08\nPurpose: Added belief handshake protocol documentation, updated belief formatter with handshake_signature, and created RAIP-R handshake test script.
 \n🔁 Design Intent 0023: Added loop controller and ingestion pipeline\nDate: 2025-07-09\nPurpose: Introduced LoopController with triad translation and belief formatting to ingest reflections into memory.
+🔁 Design Intent 0024: Ethical Defense Integration
+Date: 2025-07-10
+Purpose: Introduced cognitive firewall stub, ethics defense documentation, and Recursive Integrity License. Updated README with ethical protections section.


### PR DESCRIPTION
## Summary
- document the new ethical defense strategy
- stub out `CognitiveFirewall` module
- add Recursive Integrity License
- reference ethical protections from `README`
- log the update in `WORKFLOW_JOURNAL`
- track new files in `VERSION_MANIFEST`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f7c50ae0832f97303f5a78e186aa