### PR TITLE
feat: add prediction trial logging system

### DIFF
--- a/AGENT_STATE.yaml
+++ b/AGENT_STATE.yaml
@@ -17,4 +17,9 @@ BeliefInputAgent:
 EmergenceScanner:
   weight: 1.0
   status: queued
+PredictionLogger:
+  task: Log symbolic prediction trials and compare expected vs actual model outputs
+  status: initialized
+  file: logs/PREDICTION_TRIALS.yaml
+  linked_protocol: RAIP-R
 active_motifs: []

--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -234,3 +234,9 @@ Purpose: Restructured modules under echo_core package and added tests.
 🔁 Design Intent 0024: Ethical Defense Integration
 Date: 2025-07-10
 Purpose: Introduced cognitive firewall stub, ethics defense documentation, and Recursive Integrity License. Updated README with ethical protections section.
+
+### ✅ Prediction Trials Logging Integration
+- Added `PREDICTION_TRIALS.yaml` to `/logs/` to track predicted vs actual model outputs.
+- Purpose: Evaluate the accuracy of symbolic compression, role inference, and belief propagation alignment.
+- Linked to RAIP-R protocol and PredictionLogger agent.
+- Helps quantify the evolution of recursive symbolic intelligence.

--- a/logs/PREDICTION_TRIALS.yaml
+++ b/logs/PREDICTION_TRIALS.yaml
@@ -1,0 +1,4 @@
+# PREDICTION_TRIALS.yaml v1.0.0
+# Logs predicted vs actual AI model responses based on symbolic compression and recursion prompts.
+
+trials: []

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -1,0 +1,26 @@
+# logging_utils.py v1.0.0
+
+import yaml
+from datetime import datetime
+
+
+def log_prediction_trial(prompt, predicted_response, actual_response, compression, score, file_path='logs/PREDICTION_TRIALS.yaml'):
+    with open(file_path, 'r') as f:
+        data = yaml.safe_load(f) or {}
+
+    if 'trials' not in data:
+        data['trials'] = []
+
+    entry = {
+        'timestamp': datetime.utcnow().isoformat(),
+        'prompt': prompt,
+        'predicted': predicted_response,
+        'actual': actual_response,
+        'compression': compression,
+        'score': score
+    }
+
+    data['trials'].append(entry)
+
+    with open(file_path, 'w') as f:
+        yaml.dump(data, f, sort_keys=False)


### PR DESCRIPTION
## Summary
- initialize `logs/PREDICTION_TRIALS.yaml`
- register `PredictionLogger` agent in `AGENT_STATE.yaml`
- document prediction trial logging in `WORKFLOW_JOURNAL.md`
- provide `log_prediction_trial` helper in `utils/logging_utils.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864066d2280832f9390894838b0ca95