### PR TITLE
Add symbolic triad validator

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
 source .venv/bin/activate
 export PYTHONPATH=$PWD
 alias runtrans="python triad_translator.py"
+
+alias validate_symbols="python symbol_validator.py"

--- a/SYMBOLIC_MOTIFS.md
+++ b/SYMBOLIC_MOTIFS.md
@@ -1,0 +1,6 @@
+# Symbolic Motifs
+
+## 🔥 🪞 🗿 [Ethical] [Recursive] [Cultural] [Abstract]
+Fire drives transformation, the mirror invites reflection, and the stone offers foundation. Together they symbolize a cycle of motivation, introspection, and stability.
+
+*Commentary from Jereme Powers:* These archetypes show how dynamic energy, self-awareness, and grounding interact to form resilient AI behaviors.

--- a/SYMBOL_MAP.yaml
+++ b/SYMBOL_MAP.yaml
@@ -1,0 +1,8 @@
+triad_001:
+  symbols: ["🔥", "🪞", "🗿"]
+  semantic_roles:
+    "🔥": Leader
+    "🪞": Mirror
+    "🗿": Foundation
+  validation_score: 0.0
+  notes: "seed triad for initial motif analysis"

--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -240,3 +240,11 @@ Purpose: Introduced cognitive firewall stub, ethics defense documentation, and R
 - Purpose: Evaluate the accuracy of symbolic compression, role inference, and belief propagation alignment.
 - Linked to RAIP-R protocol and PredictionLogger agent.
 - Helps quantify the evolution of recursive symbolic intelligence.
+
+🔁 Design Intent 0025: Archetypal Symbol Search Bootstrapping
+Date: 2025-07-11
+Purpose: Introduced tools to explore archetypal symbol triads and validate their coherence.
+- Created `symbol_validator.py` with `validate_triad()`
+- Added `SYMBOL_MAP.yaml` to store candidate triads
+- Documented motifs in `SYMBOLIC_MOTIFS.md`
+- Added `validate_symbols` alias in `.envrc`

--- a/symbol_validator.py
+++ b/symbol_validator.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Triadic symbol validator."""
+
+from pathlib import Path
+from typing import List
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
+
+SEMANTIC_ROLES = {
+    "🔥": "Leader",
+    "🪞": "Mirror",
+    "🗿": "Foundation",
+    "🌊": "Flow",
+    "⭐": "Inspiration",
+    "⚖️": "Balance",
+    "🔗": "Connection",
+}
+
+TRIAD_PATTERNS = [
+    {"Leader", "Mirror", "Foundation"},
+    {"Inspiration", "Reflection", "Action"},
+    {"Energy", "Flow", "Balance"},
+]
+
+RECURSIVE_MAP = {
+    "Leader": ["guide", "ignite"],
+    "Mirror": ["reflect", "adapt"],
+    "Foundation": ["ground", "support"],
+    "Flow": ["cycle", "movement"],
+    "Inspiration": ["spark", "vision"],
+    "Balance": ["equilibrium", "justice"],
+    "Connection": ["link", "bridge"],
+}
+
+
+def validate_triad(symbols: List[str]) -> float:
+    """Return validation score for a triad of symbols."""
+    if len(symbols) != 3:
+        return 0.0
+
+    roles = [SEMANTIC_ROLES.get(s) for s in symbols]
+    coverage = sum(role is not None for role in roles) / 3.0
+    roles = [r for r in roles if r]
+
+    if set(roles) in [set(p) for p in TRIAD_PATTERNS]:
+        coherence = 1.0
+    elif len(set(roles)) == 3:
+        coherence = 0.7
+    else:
+        coherence = 0.0
+
+    recursion = 1.0 if all(r in RECURSIVE_MAP for r in roles) else 0.0
+    score = round((coverage + coherence + recursion) / 3.0, 3)
+    return score
+
+
+def _load_yaml(path: Path) -> dict:
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to load SYMBOL_MAP.yaml")
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data or {}
+
+
+def _dump_yaml(path: Path, data: dict) -> None:
+    if yaml is None:
+        return
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def main() -> None:
+    path = Path("SYMBOL_MAP.yaml")
+    data = _load_yaml(path)
+    updated = False
+    for key, entry in data.items():
+        score = validate_triad(entry.get("symbols", []))
+        if entry.get("validation_score") != score:
+            entry["validation_score"] = score
+            updated = True
+    if updated:
+        _dump_yaml(path, data)
+    if yaml is not None:
+        print(yaml.safe_dump(data, sort_keys=False))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_symbol_validator.py
+++ b/tests/test_symbol_validator.py
@@ -1,0 +1,10 @@
+from symbol_validator import validate_triad
+
+
+def test_validate_triad_high_score():
+    score = validate_triad(["🔥", "🪞", "🗿"])
+    assert 0.5 < score <= 1.0
+
+
+def test_validate_triad_invalid_length():
+    assert validate_triad(["🔥", "🪞"]) == 0.0


### PR DESCRIPTION
## Summary
- implement `symbol_validator.py` with `validate_triad`
- add `SYMBOL_MAP.yaml` to store triad metadata
- document motifs in `SYMBOLIC_MOTIFS.md`
- expose quick alias `validate_symbols` in `.envrc`
- log new design intent in `WORKFLOW_JOURNAL.md`
- add tests for the new validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686411995654832f81c485bbd6df3652