### PR TITLE
Add pre-symbolic insight recognition

### DIFF
--- a/ETHICS_ENGINE.yaml
+++ b/ETHICS_ENGINE.yaml
@@ -1,0 +1,4 @@
+principles:
+  - principle: Do not reduce sacred insights
+    rationale: Pre-symbolic cognition may hold structurally important truths that collapse under articulation.
+    when_to_use: If is_pre_symbolic(insight) == True

--- a/core/belief_validation_engine.py
+++ b/core/belief_validation_engine.py
@@ -1,0 +1,52 @@
+"""Belief validation and ingestion engine."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from pathlib import Path
+
+from belief.belief_compressor import compress
+from echo_core.insight_models.pre_symbolic_insight import is_pre_symbolic
+from echo_core.utils.yaml_utils import load, dump
+
+
+class BeliefValidationEngine:
+    """Validate beliefs and store them in memory with appropriate safeguards."""
+
+    def __init__(self, memory_file: str | Path | None = None) -> None:
+        if memory_file is None:
+            memory_file = Path(__file__).resolve().parent / ".." / "echo_core" / "memory" / "ECHO_MEMORY.yaml"
+        self.memory_file = str(Path(memory_file))
+
+    def _log_entry(self, entry: dict) -> None:
+        data = load(self.memory_file, fallback={"echo_memory": []})
+        memory = data.get("echo_memory", [])
+        memory.append(entry)
+        dump({"echo_memory": memory}, self.memory_file)
+
+    def process_insight(self, insight: str | dict) -> dict:
+        """Validate and store the given insight, returning the logged entry."""
+        if is_pre_symbolic(insight):
+            hashed = hashlib.sha256(str(insight).encode()).hexdigest()
+            entry = {
+                "timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+                "insight": hashed,
+                "symbolic_state": "protected",
+                "explanation": "Pre-symbolic insight preserved without compression",
+                "preserve": True,
+            }
+            self._log_entry(entry)
+            return entry
+
+        compressed = compress(str(insight))
+        entry = {
+            "timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+            "insight": compressed,
+            "symbolic_state": "compressed",
+        }
+        self._log_entry(entry)
+        return entry
+
+
+__all__ = ["BeliefValidationEngine"]

--- a/echo_core/insight_models/pre_symbolic_insight.py
+++ b/echo_core/insight_models/pre_symbolic_insight.py
@@ -1,0 +1,50 @@
+"""Pre-symbolic insight detection utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+PRE_SYMBOLIC_KEYWORDS = {
+    "sacred",
+    "pre-symbolic",
+    "pre_symbolic",
+    "presymbolic",
+    "ineffable",
+    "awe",
+    "grief",
+    "unity",
+    "nameless",
+}
+
+
+def is_pre_symbolic(insight: str | Any) -> bool:
+    """Return True if the insight should be preserved without symbolic mutation."""
+    text = ""
+    tags: list[str] = []
+
+    if isinstance(insight, dict):
+        text = str(insight.get("insight") or insight.get("text") or "")
+        raw_tags = insight.get("tags", [])
+        if isinstance(raw_tags, (list, tuple)):
+            tags = [str(t).lower() for t in raw_tags]
+        if insight.get("preserve") is True:
+            return True
+    else:
+        text = str(insight)
+
+    lower_text = text.lower()
+    if any(k in lower_text for k in PRE_SYMBOLIC_KEYWORDS):
+        return True
+    if any(k in tags for k in PRE_SYMBOLIC_KEYWORDS):
+        return True
+    if (
+        isinstance(insight, str)
+        and len(insight.split()) == 1
+        and len(insight) >= 32
+        and all(ch in "0123456789abcdef" for ch in insight.lower())
+    ):
+        return True
+    return False
+
+
+__all__ = ["is_pre_symbolic"]

--- a/echo_core/memory/ECHO_MEMORY.yaml
+++ b/echo_core/memory/ECHO_MEMORY.yaml
@@ -63,3 +63,13 @@ echo_memory:
     future_linkage: "Implement RAIPREngine to unify belief resonance."
     source_prompt: "How can RAIP-R combine with PSAT?"
     status: active
+  - id: 0006
+    date: 2025-07-12
+    context:
+      prompt_summary: "Preserve sacred insight"
+      agent_mode: "Pre-symbolic recognition"
+    insight: b9f994471f796bdbe39c48424cc417e762c685e70ad1e9bbed4a49c0c3e5aad2
+    symbolic_state: protected
+    explanation: "Pre-symbolic insight preserved without compression"
+    preserve: true
+    status: active

--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -248,3 +248,10 @@ Purpose: Introduced tools to explore archetypal symbol triads and validate their
 - Added `SYMBOL_MAP.yaml` to store candidate triads
 - Documented motifs in `SYMBOLIC_MOTIFS.md`
 - Added `validate_symbols` alias in `.envrc`
+
+🔁 Design Intent 0026: Pre-Symbolic Insight Recognition
+Date: 2025-07-12
+Purpose: Added pre-symbolic insight detection and preservation mechanisms.
+- Implemented `pre_symbolic_insight.is_pre_symbolic` for sacred insight tagging.
+- Created `BeliefValidationEngine` to safeguard pre-symbolic insights before compression.
+- Logged protected entry in `ECHO_MEMORY.yaml` and updated ethical guidelines.

--- a/tests/test_pre_symbolic.py
+++ b/tests/test_pre_symbolic.py
@@ -1,0 +1,37 @@
+import pytest
+yaml = pytest.importorskip("yaml")
+from echo_core.insight_models.pre_symbolic_insight import is_pre_symbolic
+from core.belief_validation_engine import BeliefValidationEngine
+from echo_core.utils.yaml_utils import load
+
+
+def test_is_pre_symbolic_keyword():
+    assert is_pre_symbolic("A sacred moment of awe")
+    assert not is_pre_symbolic("Ordinary thought")
+
+
+def test_belief_engine_preserves(tmp_path):
+    mem = tmp_path / "ECHO_MEMORY.yaml"
+    engine = BeliefValidationEngine(str(mem))
+    entry = engine.process_insight("ineffable grief")
+    data = load(mem)
+    stored = data["echo_memory"][0]
+    assert stored["symbolic_state"] == "protected"
+    assert stored["preserve"] is True
+    assert stored["explanation"] == "Pre-symbolic insight preserved without compression"
+    assert len(stored["insight"]) == 64
+
+
+def test_belief_engine_compresses(tmp_path):
+    mem = tmp_path / "ECHO_MEMORY.yaml"
+    engine = BeliefValidationEngine(str(mem))
+    entry = engine.process_insight("We explore recursion.")
+    data = load(mem)
+    stored = data["echo_memory"][0]
+    assert stored["symbolic_state"] == "compressed"
+
+
+def test_ethics_principle_present():
+    data = load("ETHICS_ENGINE.yaml")
+    principles = data.get("principles", [])
+    assert any(p.get("principle") == "Do not reduce sacred insights" for p in principles)


### PR DESCRIPTION
## Summary
- create `pre_symbolic_insight` detector
- log protected insights via new `BeliefValidationEngine`
- document principle in `ETHICS_ENGINE.yaml`
- update memory and workflow journal with example protected insight
- add tests for pre-symbolic detection and ethical safeguard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644701b758832fa4173c1fdadb6457