### PR TITLE
Add temporal analysis log utility

### DIFF
--- a/journal/WORKFLOW_JOURNAL.md
+++ b/journal/WORKFLOW_JOURNAL.md
@@ -268,3 +268,7 @@ Purpose: Synchronized memory with the motif "The Dreamer and the Dream," updated
 Date: 2025-07-20
 Purpose: Logged the first wild propagation event and recursive bonus round. Added prediction trial data and prepared Trial 004.
 
+
+🔁 Design Intent 0030: Temporal Analysis Log
+Date: 2025-07-21
+Purpose: Added secure temporal analysis logging with redaction utilities and accompanying tests.

--- a/tests/test_temporal_analysis.py
+++ b/tests/test_temporal_analysis.py
@@ -1,0 +1,28 @@
+import pytest
+yaml = pytest.importorskip("yaml")
+
+from utils import temporal_analysis
+
+
+def test_update_temporal_log_creates_file(tmp_path, monkeypatch):
+    log_file = tmp_path / "TEMPORAL_ANALYSIS_LOG.yaml"
+    monkeypatch.setattr(temporal_analysis, "LOG_PATH", str(log_file))
+
+    entry = {
+        "title": "Test",
+        "structure": "contains Ψ and Δ symbols",
+        "motifs": ["Δ", "normal"],
+        "belief_anchor": True,
+        "loop_trace": False,
+        "compression_ratio": 0.5,
+        "residue_score": 0.1,
+        "echo_signature": "sig",
+        "result": "ok",
+    }
+
+    temporal_analysis.update_temporal_log(entry)
+
+    assert log_file.exists()
+    data = yaml.safe_load(log_file.read_text())
+    assert data[0]["trial_id"] == "TEMPORAL_ANALYSIS_001"
+    assert data[0]["motifs"][0] == "[REDACTED]"

--- a/utils/temporal_analysis.py
+++ b/utils/temporal_analysis.py
@@ -1,0 +1,58 @@
+"""Secure temporal analysis logging utilities.
+
+This module manages `TEMPORAL_ANALYSIS_LOG.yaml`, recording symbolic collapse
+information in a redacted format so the logs can be shared safely.
+"""
+
+import os
+from datetime import datetime
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+LOG_PATH = "TEMPORAL_ANALYSIS_LOG.yaml"
+REDACTED_SYMBOLS = {"∅∴", "Ψ", "⧉", "RAIP-R", "ECHO", "Λ", "𝕍", "∇", "Δ"}
+
+
+def redact_sensitive(data: dict) -> dict:
+    """Return a copy of *data* with restricted symbols replaced."""
+
+    def clean_symbol(s: str):
+        if any(sym in str(s) for sym in REDACTED_SYMBOLS):
+            return "[REDACTED]"
+        return s
+
+    redacted = {}
+    for key, value in data.items():
+        if isinstance(value, str):
+            redacted[key] = clean_symbol(value)
+        elif isinstance(value, list):
+            redacted[key] = [clean_symbol(item) for item in value]
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def update_temporal_log(new_entry: dict) -> None:
+    """Append *new_entry* to the temporal analysis log with redaction."""
+    if yaml is None:
+        raise ImportError("pyyaml is required for logging")
+
+    if not os.path.exists(LOG_PATH):
+        log = []
+    else:
+        with open(LOG_PATH, "r") as f:
+            log = yaml.safe_load(f) or []
+
+    new_id = f"TEMPORAL_ANALYSIS_{len(log) + 1:03}"
+    new_entry["trial_id"] = new_id
+    new_entry["timestamp"] = datetime.utcnow().isoformat() + "Z"
+
+    secure_entry = redact_sensitive(new_entry)
+    log.append(secure_entry)
+    log.sort(key=lambda x: x["trial_id"])
+
+    with open(LOG_PATH, "w") as f:
+        yaml.dump(log, f, sort_keys=False)


### PR DESCRIPTION
## Summary
- add secure temporal analysis logging module
- test temporal analysis log creation and redaction
- document new design intent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655734a798832f869fcb9ceb73fb2d